### PR TITLE
Add TURN-based ICE endpoint and dynamic ICE integration

### DIFF
--- a/frontend/src/lib/ice.ts
+++ b/frontend/src/lib/ice.ts
@@ -1,0 +1,146 @@
+import { iceServers as fallbackIceServers } from './constants';
+
+export type IceServer = RTCIceServer;
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_UID = 'web';
+const ICE_ENDPOINT = import.meta.env.VITE_ICE_URL || '/ice';
+export const DYNAMIC_ICE_ENABLED = import.meta.env.VITE_USE_DYNAMIC_ICE === 'true';
+
+interface CacheEntry {
+  timestamp: number;
+  servers: RTCIceServer[];
+}
+
+const cache = new Map<string, CacheEntry>();
+const pendingRequests = new Map<string, Promise<RTCIceServer[]>>();
+
+const isIceServer = (value: unknown): value is RTCIceServer => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<RTCIceServer>;
+  if (typeof candidate.urls === 'string') {
+    return true;
+  }
+  return Array.isArray(candidate.urls);
+};
+
+const extractIceServers = (payload: unknown): RTCIceServer[] => {
+  if (!payload) {
+    return [];
+  }
+
+  if (Array.isArray(payload)) {
+    return payload.filter(isIceServer) as RTCIceServer[];
+  }
+
+  if (typeof payload === 'object') {
+    const maybeServers = (payload as { iceServers?: unknown }).iceServers;
+    if (Array.isArray(maybeServers)) {
+      return maybeServers.filter(isIceServer) as RTCIceServer[];
+    }
+  }
+
+  return [];
+};
+
+const normalizeUid = (uid?: string): string => {
+  if (!uid) {
+    return DEFAULT_UID;
+  }
+  const trimmed = uid.trim();
+  if (!trimmed) {
+    return DEFAULT_UID;
+  }
+  return trimmed.slice(0, 64);
+};
+
+const buildRequestUrl = (uid: string): string => {
+  if (!uid || uid === DEFAULT_UID) {
+    return ICE_ENDPOINT;
+  }
+  const separator = ICE_ENDPOINT.includes('?') ? '&' : '?';
+  return `${ICE_ENDPOINT}${separator}uid=${encodeURIComponent(uid)}`;
+};
+
+const requestIceServers = async (uid: string): Promise<RTCIceServer[]> => {
+  if (typeof fetch !== 'function') {
+    console.warn('[ice] fetch API is not available in the current environment.');
+    return [];
+  }
+  const response = await fetch(buildRequestUrl(uid), { credentials: 'omit' });
+  if (!response.ok) {
+    throw new Error(`ICE fetch failed with status ${response.status}`);
+  }
+  const payload = await response.json();
+  return extractIceServers(payload);
+};
+
+export const FALLBACK_ICE_SERVERS = fallbackIceServers;
+
+export const getFallbackIceServers = (): RTCIceServer[] => [...fallbackIceServers];
+
+export const getDynamicIceServers = async (uid?: string): Promise<RTCIceServer[]> => {
+  if (!DYNAMIC_ICE_ENABLED) {
+    return [];
+  }
+
+  const normalizedUid = normalizeUid(uid);
+  const cached = cache.get(normalizedUid);
+  const now = Date.now();
+
+  if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+    return cached.servers;
+  }
+
+  const pending = pendingRequests.get(normalizedUid);
+  if (pending) {
+    try {
+      return await pending;
+    } catch {
+      return [];
+    }
+  }
+
+  const requestPromise = (async () => {
+    try {
+      const servers = await requestIceServers(normalizedUid);
+      cache.set(normalizedUid, { timestamp: Date.now(), servers });
+      return servers;
+    } catch (error) {
+      console.error(`[ice] Failed to fetch ICE servers for uid "${normalizedUid}"`, error);
+      throw error;
+    } finally {
+      pendingRequests.delete(normalizedUid);
+    }
+  })();
+
+  pendingRequests.set(normalizedUid, requestPromise);
+
+  try {
+    return await requestPromise;
+  } catch {
+    return [];
+  }
+};
+
+export const getEffectiveIceServers = async (uid?: string): Promise<RTCIceServer[]> => {
+  const dynamicServers = await getDynamicIceServers(uid);
+  return [...fallbackIceServers, ...dynamicServers];
+};
+
+export const prefetchIceServers = (uid?: string) => {
+  if (!DYNAMIC_ICE_ENABLED) {
+    return;
+  }
+  if (typeof window === 'undefined') {
+    return;
+  }
+  void getDynamicIceServers(uid);
+};
+
+export const clearIceCache = () => {
+  cache.clear();
+  pendingRequests.clear();
+};

--- a/frontend/src/lib/peerConnection.ts
+++ b/frontend/src/lib/peerConnection.ts
@@ -1,0 +1,25 @@
+import { getEffectiveIceServers } from './ice';
+
+interface CreatePeerConnectionOptions {
+  uid?: string;
+  forceRelay?: boolean;
+  configuration?: RTCConfiguration;
+}
+
+export const createPeerConnection = async (
+  options: CreatePeerConnectionOptions = {},
+): Promise<RTCPeerConnection> => {
+  const { uid, forceRelay, configuration } = options;
+  const iceServers = await getEffectiveIceServers(uid);
+
+  const rtcConfiguration: RTCConfiguration = {
+    ...configuration,
+    iceServers,
+  };
+
+  if (forceRelay) {
+    rtcConfiguration.iceTransportPolicy = 'relay';
+  }
+
+  return new RTCPeerConnection(rtcConfiguration);
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client';
 import 'antd/dist/reset.css';
 import './index.css';
 import App from './App.tsx';
+import { prefetchIceServers } from './lib/ice';
+
+prefetchIceServers();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/server/api/ice.test.ts
+++ b/server/api/ice.test.ts
@@ -1,0 +1,114 @@
+import request from 'supertest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = ['TURN_SECRET', 'TURN_HOST', 'TURN_REALM', 'ICE_TTL_SEC'] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+type EnvSnapshot = Partial<Record<EnvKey, string | undefined>>;
+
+const originalEnv: EnvSnapshot = ENV_KEYS.reduce<EnvSnapshot>((acc, key) => {
+  acc[key] = process.env[key];
+  return acc;
+}, {});
+
+const applyEnv = (values: EnvSnapshot) => {
+  for (const key of ENV_KEYS) {
+    const value = values[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+};
+
+const importApp = async () => {
+  const module = await import('#server');
+  return module.app;
+};
+
+describe('GET /ice', () => {
+  beforeEach(() => {
+    applyEnv(originalEnv);
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    applyEnv(originalEnv);
+    vi.useRealTimers();
+  });
+
+  it('returns 500 when TURN_SECRET is not configured', async () => {
+    applyEnv({ TURN_SECRET: undefined, TURN_HOST: 'turn.example.com', TURN_REALM: 'example.com' });
+    const app = await importApp();
+
+    const response = await request(app).get('/ice').expect(500);
+
+    expect(response.body).toEqual({ error: 'TURN_SECRET not set' });
+  });
+
+  it('generates ephemeral credentials and ice servers using HMAC', async () => {
+    applyEnv({
+      TURN_SECRET: 'test-secret',
+      TURN_HOST: 'turn.test.example',
+      TURN_REALM: 'test.example',
+      ICE_TTL_SEC: '86400',
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+
+    const app = await importApp();
+
+    const response = await request(app).get('/ice?uid=test-user').expect(200);
+
+    const body = response.body as {
+      username: string;
+      credential: string;
+      realm: string;
+      ttl: number;
+      iceServers: Array<{ urls: string[]; username?: string; credential?: string }>;
+    };
+
+    expect(body.realm).toBe('test.example');
+    expect(body.ttl).toBe(86400);
+    expect(body.username).toBe('1704153600:test-user');
+    expect(body.credential).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    expect(body.iceServers).toHaveLength(2);
+    expect(body.iceServers[0].urls).toEqual([
+      'stun:turn.test.example:3478',
+      'stun:turn.test.example:80',
+    ]);
+    expect(body.iceServers[1]).toEqual({
+      urls: [
+        'turn:turn.test.example:3478?transport=udp',
+        'turn:turn.test.example:3478?transport=tcp',
+        'turns:turn.test.example:443?transport=tcp',
+      ],
+      username: '1704153600:test-user',
+      credential: body.credential,
+    });
+  });
+
+  it('caches responses per uid for five minutes', async () => {
+    applyEnv({
+      TURN_SECRET: 'cache-secret',
+      TURN_HOST: 'turn.cache.example',
+      TURN_REALM: 'cache.example',
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-01T12:00:00.000Z'));
+
+    const app = await importApp();
+
+    const first = await request(app).get('/ice?uid=user-a').expect(200);
+    const second = await request(app).get('/ice?uid=user-a').expect(200);
+    const third = await request(app).get('/ice?uid=user-b').expect(200);
+
+    expect(first.body.credential).toBe(second.body.credential);
+    expect(second.body.username).toBe('1714651200:user-a');
+    expect(third.body.username).toBe('1714651200:user-b');
+    expect(third.body.credential).not.toBe(first.body.credential);
+  });
+});


### PR DESCRIPTION
## Summary
- add a GET /ice endpoint that issues HMAC TURN credentials with per-uid in-memory caching and server-side tests
- introduce a dynamic ICE helper with client-side caching/prefetch and createPeerConnection wrapper for async TURN setup
- update call and streaming flows to await dynamic ICE data while keeping STUN fallbacks and relay support flagging

## Testing
- npm run build:server
- npm run test:server
- npm --prefix frontend run build
- npm --prefix frontend run test

------
https://chatgpt.com/codex/tasks/task_e_68ceaebdc9a0832abd166d20ddb6485c