### PR TITLE
feat(call): remember media toggles and support fullscreen stage

### DIFF
--- a/frontend/src/features/call/components/CallControls.tsx
+++ b/frontend/src/features/call/components/CallControls.tsx
@@ -2,6 +2,8 @@ import { Button, Space, Tag, Tooltip } from 'antd';
 import {
   AudioMutedOutlined,
   AudioOutlined,
+  FullscreenExitOutlined,
+  FullscreenOutlined,
   RetweetOutlined,
   TeamOutlined,
   VideoCameraAddOutlined,
@@ -15,6 +17,9 @@ type CallControlsProps = {
   onToggleMicrophone: () => void;
   onToggleCamera: () => void;
   onSwitchCamera: () => void;
+  isFullscreen: boolean;
+  canToggleFullscreen: boolean;
+  onToggleFullscreen: () => void;
   participantsCount: number;
 };
 
@@ -25,6 +30,9 @@ export const CallControls = ({
   onToggleMicrophone,
   onToggleCamera,
   onSwitchCamera,
+  isFullscreen,
+  canToggleFullscreen,
+  onToggleFullscreen,
   participantsCount,
 }: CallControlsProps) => (
   <Space size="middle" wrap>
@@ -47,6 +55,15 @@ export const CallControls = ({
     <Tooltip title="Переключить камеру">
       <Button icon={<RetweetOutlined />} onClick={onSwitchCamera} disabled={!canSwitchCamera}>
         Сменить камеру
+      </Button>
+    </Tooltip>
+    <Tooltip title={isFullscreen ? 'Свернуть из полноэкранного режима' : 'На весь экран'}>
+      <Button
+        icon={isFullscreen ? <FullscreenExitOutlined /> : <FullscreenOutlined />}
+        onClick={onToggleFullscreen}
+        disabled={!canToggleFullscreen}
+      >
+        {isFullscreen ? 'Свернуть' : 'На весь экран'}
       </Button>
     </Tooltip>
     <Tag icon={<TeamOutlined />} color="blue">

--- a/frontend/src/features/call/components/CallParticipantsGrid.tsx
+++ b/frontend/src/features/call/components/CallParticipantsGrid.tsx
@@ -1,35 +1,119 @@
+import { useCallback } from 'react';
 import type { RefObject } from 'react';
 
 import type { RemoteParticipant } from '../hooks/useCallPeers';
 
 type CallParticipantsGridProps = {
   localVideoRef: RefObject<HTMLVideoElement | null>;
+  localStreamRef: RefObject<MediaStream | null>;
   remoteParticipants: RemoteParticipant[];
+  containerRef: RefObject<HTMLDivElement | null>;
+  isFullscreen: boolean;
 };
 
 export const CallParticipantsGrid = ({
   localVideoRef,
+  localStreamRef,
   remoteParticipants,
-}: CallParticipantsGridProps) => (
-  <div className="video-grid">
-    <div className="video-grid__item">
-      <video ref={localVideoRef} autoPlay playsInline muted className="video-grid__video" />
-      <span className="video-grid__label">Вы</span>
-    </div>
-    {remoteParticipants.map((participant) => (
-      <div key={participant.id} className="video-grid__item">
-        <video
-          autoPlay
-          playsInline
-          ref={(element) => {
-            if (element) {
-              element.srcObject = participant.stream;
-              element.play().catch(() => undefined);
-            }
-          }}
-        />
-        <span className="video-grid__label">{participant.id.slice(0, 6)}</span>
+  containerRef,
+  isFullscreen,
+}: CallParticipantsGridProps) => {
+  const handleLocalVideoRef = useCallback(
+    (element: HTMLVideoElement | null) => {
+      localVideoRef.current = element;
+      if (!element) {
+        return;
+      }
+
+      const stream = localStreamRef.current;
+      if (stream && element.srcObject !== stream) {
+        element.srcObject = stream;
+      }
+
+      element.muted = true;
+      if (element.srcObject) {
+        element.play().catch(() => undefined);
+      }
+    },
+    [localStreamRef, localVideoRef],
+  );
+
+  if (isFullscreen && remoteParticipants.length > 0) {
+    const [primaryParticipant, ...secondaryParticipants] = remoteParticipants;
+
+    return (
+      <div ref={containerRef} className="video-stage video-stage--fullscreen">
+        <div className="video-stage__primary">
+          <video
+            autoPlay
+            playsInline
+            ref={(element) => {
+              if (element) {
+                element.srcObject = primaryParticipant.stream;
+                element.play().catch(() => undefined);
+              }
+            }}
+            className="video-stage__primary-video"
+          />
+          <span className="video-grid__label">{primaryParticipant.id.slice(0, 6)}</span>
+        </div>
+
+        <div className="video-stage__local-preview">
+          <video
+            ref={handleLocalVideoRef}
+            autoPlay
+            playsInline
+            muted
+            className="video-stage__local-video"
+          />
+          <span className="video-grid__label">Вы</span>
+        </div>
+
+        {secondaryParticipants.length > 0 && (
+          <div className="video-stage__thumbnails">
+            {secondaryParticipants.map((participant) => (
+              <div key={participant.id} className="video-stage__thumbnail">
+                <video
+                  autoPlay
+                  playsInline
+                  ref={(element) => {
+                    if (element) {
+                      element.srcObject = participant.stream;
+                      element.play().catch(() => undefined);
+                    }
+                  }}
+                  className="video-stage__thumbnail-video"
+                />
+                <span className="video-grid__label">{participant.id.slice(0, 6)}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-    ))}
-  </div>
-);
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="video-grid">
+      <div className="video-grid__item">
+        <video ref={handleLocalVideoRef} autoPlay playsInline muted className="video-grid__video" />
+        <span className="video-grid__label">Вы</span>
+      </div>
+      {remoteParticipants.map((participant) => (
+        <div key={participant.id} className="video-grid__item">
+          <video
+            autoPlay
+            playsInline
+            ref={(element) => {
+              if (element) {
+                element.srcObject = participant.stream;
+                element.play().catch(() => undefined);
+              }
+            }}
+          />
+          <span className="video-grid__label">{participant.id.slice(0, 6)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -128,6 +128,89 @@ a:hover {
   font-size: 12px;
 }
 
+.video-stage {
+  position: relative;
+  width: 100%;
+  background: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  min-height: 360px;
+  display: flex;
+}
+
+.video-stage video {
+  display: block;
+}
+
+.video-stage--fullscreen {
+  border-radius: 0;
+  height: 100%;
+  min-height: 100vh;
+}
+
+.video-stage__primary {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.video-stage__primary-video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+.video-stage__local-preview {
+  position: absolute;
+  bottom: 24px;
+  right: 24px;
+  width: min(240px, 32%);
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+.video-stage__local-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #000;
+}
+
+.video-stage__thumbnails {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.video-stage__thumbnail {
+  width: clamp(120px, 20vw, 200px);
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.video-stage__thumbnail-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #000;
+}
+
+.video-stage--fullscreen .video-grid__label {
+  z-index: 2;
+}
+
 .controls-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- persist microphone and camera enabled state across sessions via local storage
- add a fullscreen viewing mode with remote video focus and local preview overlay
- extend call controls and styles to support the new fullscreen layout

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b0a37bf4832aad162659c8eaf2d9