### PR TITLE
Adjust local preview and thumbnail video sizing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,7 +168,9 @@ a:hover {
   bottom: 24px;
   right: 24px;
   width: min(240px, 32%);
-  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 12px;
   overflow: hidden;
   background: #000;
@@ -177,8 +179,9 @@ a:hover {
 
 .video-stage__local-video {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
+  max-height: 100%;
+  object-fit: contain;
   background: #000;
 }
 
@@ -203,7 +206,7 @@ a:hover {
 .video-stage__thumbnail-video {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   background: #000;
 }
 


### PR DESCRIPTION
## Summary
- allow the local preview container to size itself to the incoming stream instead of forcing 16:9
- render local and thumbnail videos with object-fit: contain so vertical streams stay fully visible

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bd9d08f0832aba3ef54c5fbc4f91