### PR TITLE
Clear video srcObject when stream removed

### DIFF
--- a/frontend/src/features/call/components/CallParticipantsGrid.tsx
+++ b/frontend/src/features/call/components/CallParticipantsGrid.tsx
@@ -143,6 +143,7 @@ export const CallParticipantsGrid = ({
         element.srcObject = stream;
         streamAttached = true;
       } else if (!stream) {
+        element.srcObject = null;
         blockedElementsRef.current.delete(element);
         updateAutoplayBlockedState();
       }


### PR DESCRIPTION
## Summary
- clear video elements when their MediaStream is unavailable to avoid replaying stale media

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c908fc10832ab61571a5a3ecbf84